### PR TITLE
index: new Promise.resolve > Promise.resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ function getTransactionSize (numInputs, numOutputs) {
 
 function getFees (provider, feeName) {
 	if (typeof feeName === 'number') {
-		return new Promise.resolve(feeName);
+		return Promise.resolve(feeName);
 	} else {
 		return provider(feeName);
 	}


### PR DESCRIPTION
This was causing a type error "Promise.resolve" is not a contructor. This
pull request fixes that.